### PR TITLE
Update Dependencies for Metrics Release Versions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,6 +1,10 @@
 name: Build and Test (deprecated)
 
-on: workflow_dispatch
+on:
+  pull_request:
+    paths:
+      - 'WebService/**'
+  workflow_dispatch:
 
 jobs:
   # Doesn't work since MacOS12 is required, not available via GitHub Actions yet

--- a/WebService/Package.resolved
+++ b/WebService/Package.resolved
@@ -14,9 +14,9 @@
         "package": "Apodini",
         "repositoryURL": "https://github.com/Apodini/Apodini.git",
         "state": {
-          "branch": "feature/metrics",
-          "revision": "0d66207a71e9172d5611ad81e3484e3aaf17dca0",
-          "version": null
+          "branch": null,
+          "revision": "7f2298e764f4d35beb4a8dbb0a719bea6d1492c1",
+          "version": "0.6.1"
         }
       },
       {
@@ -24,8 +24,17 @@
         "repositoryURL": "https://github.com/Apodini/ApodiniMigrator.git",
         "state": {
           "branch": null,
-          "revision": "6a883750c1f63cc0f86946dce3afe1aaa5d9b8b2",
-          "version": "0.1.2"
+          "revision": "c2bb44275a82ec61de70e114d07eafc803d73f41",
+          "version": "0.1.4"
+        }
+      },
+      {
+        "package": "ApodiniObservePrometheus",
+        "repositoryURL": "https://github.com/Apodini/ApodiniObservePrometheus.git",
+        "state": {
+          "branch": null,
+          "revision": "c64118a6bf0ad281d4835068485ae18b24ec7270",
+          "version": "0.1.0"
         }
       },
       {
@@ -33,8 +42,8 @@
         "repositoryURL": "https://github.com/Apodini/ApodiniTypeInformation.git",
         "state": {
           "branch": null,
-          "revision": "b5b9a4d56f8b4fc28fff159e3e9349c41baf40a4",
-          "version": "0.2.0"
+          "revision": "95109a6f3cf93a828d1b0adf2cdc299e31fe5e87",
+          "version": "0.2.1"
         }
       },
       {
@@ -83,15 +92,6 @@
         }
       },
       {
-        "package": "console-kit",
-        "repositoryURL": "https://github.com/vapor/console-kit.git",
-        "state": {
-          "branch": null,
-          "revision": "75ea3b627d88221440b878e5dfccc73fd06842ed",
-          "version": "4.2.7"
-        }
-      },
-      {
         "package": "Core",
         "repositoryURL": "https://github.com/vapor/core.git",
         "state": {
@@ -107,15 +107,6 @@
           "branch": null,
           "revision": "fc5a27d6eb236141dc24e5f14eedaa2e035ae7b3",
           "version": "1.1.1"
-        }
-      },
-      {
-        "package": "FCM",
-        "repositoryURL": "https://github.com/MihaelIsaev/FCM.git",
-        "state": {
-          "branch": null,
-          "revision": "5d35a93bde97fd34879bf1f7ca198f4efacd8eca",
-          "version": "2.11.1"
         }
       },
       {
@@ -146,21 +137,21 @@
         }
       },
       {
+        "package": "fluent-sqlite-driver",
+        "repositoryURL": "https://github.com/vapor/fluent-sqlite-driver.git",
+        "state": {
+          "branch": null,
+          "revision": "9ca34be792979fb0f1dbd8e45b8af9f1e1440474",
+          "version": "4.1.0"
+        }
+      },
+      {
         "package": "jmespath.swift",
         "repositoryURL": "https://github.com/adam-fowler/jmespath.swift.git",
         "state": {
           "branch": null,
           "revision": "4a166ea71f0d9e9cc3523fc3dee516080a4c36a0",
           "version": "1.0.0"
-        }
-      },
-      {
-        "package": "jwt",
-        "repositoryURL": "https://github.com/vapor/jwt.git",
-        "state": {
-          "branch": null,
-          "revision": "f18aa4f69d9ec781d79b7b89352de326f82e17a9",
-          "version": "4.1.0"
         }
       },
       {
@@ -177,17 +168,8 @@
         "repositoryURL": "https://github.com/Apodini/MetadataSystem.git",
         "state": {
           "branch": null,
-          "revision": "5c5b7f0a01017785e3d265fa5d04f0e0b5b3a733",
-          "version": "0.1.0"
-        }
-      },
-      {
-        "package": "multipart-kit",
-        "repositoryURL": "https://github.com/vapor/multipart-kit.git",
-        "state": {
-          "branch": null,
-          "revision": "2dd9368a3c9580792b77c7ef364f3735909d9996",
-          "version": "4.5.1"
+          "revision": "06cac46a958fdf700054f12f682b5c8f27577c9f",
+          "version": "0.1.1"
         }
       },
       {
@@ -245,21 +227,12 @@
         }
       },
       {
-        "package": "routing-kit",
-        "repositoryURL": "https://github.com/vapor/routing-kit.git",
-        "state": {
-          "branch": null,
-          "revision": "a0801a36a6ad501d5ad6285cbcd4774de6b0a734",
-          "version": "4.3.0"
-        }
-      },
-      {
         "package": "Runtime",
-        "repositoryURL": "https://github.com/Supereg/Runtime.git",
+        "repositoryURL": "https://github.com/wickwirew/Runtime.git",
         "state": {
           "branch": null,
-          "revision": "596e22a518bb3f8177cd796cd77e5386098a33f8",
-          "version": "2.2.3"
+          "revision": "dad03135d7701a4e7b3a4051e75d6b37bd8e178e",
+          "version": "2.2.4"
         }
       },
       {
@@ -308,6 +281,24 @@
         }
       },
       {
+        "package": "sqlite-kit",
+        "repositoryURL": "https://github.com/vapor/sqlite-kit.git",
+        "state": {
+          "branch": null,
+          "revision": "2ec279b9c845cec254646834b66338551a024561",
+          "version": "4.0.2"
+        }
+      },
+      {
+        "package": "sqlite-nio",
+        "repositoryURL": "https://github.com/vapor/sqlite-nio.git",
+        "state": {
+          "branch": null,
+          "revision": "6481dd0b01112d082dd7eb362782126e81964138",
+          "version": "1.1.0"
+        }
+      },
+      {
         "package": "SwifCron",
         "repositoryURL": "https://github.com/MihaelIsaev/SwifCron.git",
         "state": {
@@ -321,26 +312,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "d2930e8fcf9c33162b9fcc1d522bc975e2d4179b",
-          "version": "1.0.1"
-        }
-      },
-      {
-        "package": "swift-aws-lambda-runtime",
-        "repositoryURL": "https://github.com/swift-server/swift-aws-lambda-runtime.git",
-        "state": {
-          "branch": null,
-          "revision": "699ada1724459582303c15aae64fa12ca4d33809",
-          "version": "0.5.2"
-        }
-      },
-      {
-        "package": "swift-backtrace",
-        "repositoryURL": "https://github.com/swift-server/swift-backtrace.git",
-        "state": {
-          "branch": null,
-          "revision": "d3e04a9d4b3833363fb6192065b763310b156d54",
-          "version": "1.3.1"
+          "revision": "83b23d940471b313427da226196661856f6ba3e0",
+          "version": "0.4.4"
         }
       },
       {
@@ -359,15 +332,6 @@
           "branch": null,
           "revision": "127d3745c37b5705e4bc8d16c7951c48dcc3332c",
           "version": "2.0.0"
-        }
-      },
-      {
-        "package": "swift-extras-base64",
-        "repositoryURL": "https://github.com/swift-extras/swift-extras-base64",
-        "state": {
-          "branch": null,
-          "revision": "97237cf1bc1feebaeb0febec91c1e1b9e4d839b3",
-          "version": "0.7.0"
         }
       },
       {
@@ -399,11 +363,11 @@
       },
       {
         "package": "swift-metrics-extras",
-        "repositoryURL": "https://github.com/fabianfett/swift-metrics-extras.git",
+        "repositoryURL": "https://github.com/Apodini/swift-metrics-extras.git",
         "state": {
-          "branch": "ff-add-metrics-test-utils",
-          "revision": "7872e9961cd0f19d8931c243f8f027d4469083e4",
-          "version": null
+          "branch": null,
+          "revision": "a5f54d453519af7f1d6c83d03e045463bb9e659e",
+          "version": "0.1.0"
         }
       },
       {
@@ -461,30 +425,21 @@
         }
       },
       {
-        "package": "vapor",
-        "repositoryURL": "https://github.com/vapor/vapor.git",
-        "state": {
-          "branch": null,
-          "revision": "1c4d362995a4e2a8b48969813d7a05d228be10bf",
-          "version": "4.51.0"
-        }
-      },
-      {
-        "package": "vapor-aws-lambda-runtime",
-        "repositoryURL": "https://github.com/vapor-community/vapor-aws-lambda-runtime.git",
-        "state": {
-          "branch": null,
-          "revision": "610aaed1cdd7ef434ed23bc7006000948a221527",
-          "version": "0.6.2"
-        }
-      },
-      {
         "package": "websocket-kit",
         "repositoryURL": "https://github.com/vapor/websocket-kit.git",
         "state": {
           "branch": null,
           "revision": "b1c4df8f6c848c2e977726903bbe6578eed723ad",
           "version": "2.2.0"
+        }
+      },
+      {
+        "package": "XCTAssertCrash",
+        "repositoryURL": "https://github.com/norio-nomura/XCTAssertCrash.git",
+        "state": {
+          "branch": null,
+          "revision": "880c5241254da53f32caf77248ee3d25cb2a9630",
+          "version": "0.2.0"
         }
       },
       {

--- a/WebService/Package.swift
+++ b/WebService/Package.swift
@@ -11,9 +11,8 @@ let package = Package(
         .executable(name: "WebService", targets: ["WebService"])
     ],
     dependencies: [
-        .package(url: "https://github.com/Apodini/Apodini.git", .branch("feature/metrics")),
-        //.package(url: "https://github.com/Apodini/Apodini.git", from: "0.5.0"),
-        //.package(path: "../../Apodini"),
+        .package(url: "https://github.com/Apodini/Apodini.git", .upToNextMinor(from: "0.6.1")),
+        .package(url: "https://github.com/Apodini/ApodiniObservePrometheus.git", .upToNextMinor(from: "0.1.0")),
         .package(path: "../Shared"),
         .package(url: "https://github.com/vapor/fluent-postgres-driver.git", from: "2.0.0"),
         .package(url: "https://github.com/Apodini/swift-log-elk.git", from: "0.2.0"),
@@ -29,7 +28,7 @@ let package = Package(
                 .product(name: "Apodini", package: "Apodini"),
                 .product(name: "ApodiniREST", package: "Apodini"),
                 .product(name: "ApodiniObserve", package: "Apodini"),
-                .product(name: "ApodiniObserveMetricsPrometheus", package: "Apodini"),
+                .product(name: "ApodiniObservePrometheus", package: "ApodiniObservePrometheus"),
                 .product(name: "ApodiniOpenAPI", package: "Apodini"),
                 .product(name: "ApodiniDatabase", package: "Apodini"),
                 .product(name: "ApodiniAuthorization", package: "Apodini"),

--- a/WebService/Sources/WebService/main.swift
+++ b/WebService/Sources/WebService/main.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Apodini
 import ApodiniObserve
-import ApodiniObserveMetricsPrometheus
+import ApodiniObservePrometheus
 import ApodiniOpenAPI
 import ApodiniREST
 import ApodiniDatabase
@@ -28,7 +28,7 @@ struct ExampleWebService: WebService {
         }
         
         // Defines on which hostname and port the webservice should be bound to, configurable via CLI-arguments, else defaults
-        HTTPConfiguration(port: port)
+        HTTPConfiguration(bindAddress: .interface("0.0.0.0", port: port))
         
         // Setup of ApodiniLogger with a LogstashLogHandler backend
         LoggerConfiguration(logHandlers: LogstashLogHandler.init,


### PR DESCRIPTION
# Update Dependencies for Metrics Release Versions

## :recycle: Current situation
The WebService uses the branch-specific version of ApodiniObserve (`feature/metrics`).

## :bulb: Proposed solution
We now have [a new Apodini release (0.6.1)](https://github.com/Apodini/Apodini/releases/tag/0.6.1) and [ApodiniObservePrometheus](https://github.com/Apodini/ApodiniObservePrometheus) extracted into a Swift package. This PR updates the WebService to use the latest version of these two dependencies.

# Reviewer nudging
Build and tests are still green ¯\_(ツ)_/¯